### PR TITLE
Use outerHeight/outerWidth on dragged items

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -94,8 +94,8 @@
     // Therefore it might not be the container, that actually contains the item.
     onDragStart: function ($item, container, _super, event) {
       $item.css({
-        height: $item.height(),
-        width: $item.width()
+        height: $item.outerHeight(),
+        width: $item.outerWidth()
       })
       $item.addClass(container.group.options.draggedClass)
       $("body").addClass(container.group.options.bodyClass)


### PR DESCRIPTION
Padded/bordered items that were dragged and sized using height/width were incorrectly sized.